### PR TITLE
Allows `.` (dots) in key names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.sw[a-z]
+vendor/*/
+dist/

--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ key             secret                          1               06-09 17:30:56  
 
 `read` provides the ability to print out the value of a single secret, as well as the secret's additional metadata. It does not provide the ability to print out multiple secrets in order to discourage accessing extra secret material that is unneeded. Parameter store automatically versions secrets and passing the `--version/-v` flag to read can print older versions of the secret. Default version (-1) is the latest secret.
 
+### AWS Region
+
+Chamber uses [AWS SDK for Go](https://github.com/aws/aws-sdk-go). To use a region other than what is specified in `$HOME/.aws/config`, set the environment variable "AWS_REGION".
+
+```bash
+$ AWS_REGION=us-west-2 chamber list service
+Key         Version                  LastModified      User
+apikey      3                        07-10 09:30:41    daniel-fuentes
+other       1                        07-10 09:30:35    daniel-fuentes
+```
+
+Chamber does not currently read the value of "AWS_DEFAULT_REGION". See [https://github.com/aws/aws-sdk-go#configuring-aws-region](https://github.com/aws/aws-sdk-go#configuring-aws-region) for more details.
+
 ## Releasing
 
 To cut a new release, just push a tag named `v<semver>` where `<semver>` is a valid semver version.  This tag will be used by Circle to automatically publish a github release.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Chamber
 
-Chamber is a tool for managing secrets.  Currently it does so by storing secrets in SSM Parameter Store, an AWS service for storing secrets.
+Chamber is a tool for managing secrets.  Currently it does so by storing
+secrets in SSM Parameter Store, an AWS service for storing secrets.
 
 ## Authenticating
 
-Using `chamber` requires you to be running in an environment with an authenticated AWS user which has the appropriate permission to read/write values to SSM Parameter Store.  The easiest way to do so is by using `aws-vault`, like:
+Using `chamber` requires you to be running in an environment with an
+authenticated AWS user which has the appropriate permission to read/write
+values to SSM Parameter Store.  The easiest way to do so is by using
+`aws-vault`, like:
 
 ```bash
 $ aws-vault exec prod -- chamber
 ```
 
-For this reason, it is recommended that you create an alias in your shell of choice to save yourself some typing, for example (from my `.zshrc`):
+For this reason, it is recommended that you create an alias in your shell of
+choice to save yourself some typing, for example (from my `.zshrc`):
 
 ```
 alias chamberprod='aws-vault exec production -- chamber'
@@ -18,9 +23,14 @@ alias chamberprod='aws-vault exec production -- chamber'
 
 ## Setting up KMS
 
-Chamber expects to find a KMS key with alias `parameter_store_key` in the account that you are writing/reading secrets.  You can follow the [AWS KMS documentation](http://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html) to create your key, and [follow this guide to set up your alias](http://docs.aws.amazon.com/kms/latest/developerguide/programming-aliases.html).
+Chamber expects to find a KMS key with alias `parameter_store_key` in the
+account that you are writing/reading secrets.  You can follow the [AWS KMS
+documentation](http://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html)
+to create your key, and [follow this guide to set up your
+alias](http://docs.aws.amazon.com/kms/latest/developerguide/programming-aliases.html).
 
-If you are a [Terraform](https://www.terraform.io/) user, you can create your key with the following:
+If you are a [Terraform](https://www.terraform.io/) user, you can create your
+key with the following:
 
 ```HCL
 resource "aws_kms_key" "parameter_store" {
@@ -35,17 +45,22 @@ resource "aws_kms_alias" "parameter_store_alias" {
 }
 ```
 
-If you'd like to use an alternate KMS key to encrypt your secrets, you can set the environment variable `CHAMBER_KMS_KEY_ALIAS`.
+If you'd like to use an alternate KMS key to encrypt your secrets, you can set
+the environment variable `CHAMBER_KMS_KEY_ALIAS`.
 
 ## Usage
 
 ### Writing Secrets
 
 ```bash
-$ chamber write <service> <key> <value>
+$ chamber write <service> <key> <value|->
 ```
 
-This operation will write a secret into the secret store. If a secret with that key already exists, it will increment the version and store a new value.
+This operation will write a secret into the secret store. If a secret with that
+key already exists, it will increment the version and store a new value.
+
+If `-` is provided as the value argument, the value will be read from standard
+input.
 
 
 ### Listing Secrets
@@ -57,7 +72,9 @@ apikey      2                        06-09 17:30:56    daniel-fuentes
 other       1                        06-09 17:30:34    daniel-fuentes
 ```
 
-Listing secrets should show the key names for a given service, along with other useful metadata including when the secret was last modified, who modified it, and what the current version is.
+Listing secrets should show the key names for a given service, along with other
+useful metadata including when the secret was last modified, who modified it,
+and what the current version is.
 
 
 ### Historic view
@@ -68,16 +85,23 @@ Event       Version     Date            User
 Created     1           06-09 17:30:19  daniel-fuentes
 Updated     2           06-09 17:30:56  daniel-fuentes
 ```
-The history command gives a historical view of a given secret. This view is useful for auditing changes, and can point you toward the user who made the change so it's easier to find out why changes were made.
+The `history` command gives a historical view of a given secret. This view is
+useful for auditing changes, and can point you toward the user who made the
+change so it's easier to find out why changes were made.
 
 ### Exec
 ```bash
 $ chamber exec <service...> -- <your executable>
 ```
 
-`exec` populates the environment with the secrets from the specified services and executes the given command.  Secret keys are converted to upper case (for example a secret with key `secret_key` will become `SECRET_KEY`).
+`exec` populates the environment with the secrets from the specified services
+and executes the given command.  Secret keys are converted to upper case (for
+example a secret with key `secret_key` will become `SECRET_KEY`).
 
-Secrets from services are loaded in the order specified in the command.  For example, if you do `chamber exec app apptwo -- ...` and both apps have a secret named `api_key`, the `api_key` from `apptwo` will be the one set in your environment.
+Secrets from services are loaded in the order specified in the command.  For
+example, if you do `chamber exec app apptwo -- ...` and both apps have a secret
+named `api_key`, the `api_key` from `apptwo` will be the one set in your
+environment.
 
 ### Reading
 ```bash
@@ -86,11 +110,18 @@ Key             Value                           Version         LastModified    
 key             secret                          1               06-09 17:30:56  daniel-fuentes
 ```
 
-`read` provides the ability to print out the value of a single secret, as well as the secret's additional metadata. It does not provide the ability to print out multiple secrets in order to discourage accessing extra secret material that is unneeded. Parameter store automatically versions secrets and passing the `--version/-v` flag to read can print older versions of the secret. Default version (-1) is the latest secret.
+`read` provides the ability to print out the value of a single secret, as well
+as the secret's additional metadata. It does not provide the ability to print
+out multiple secrets in order to discourage accessing extra secret material
+that is unneeded. Parameter store automatically versions secrets and passing
+the `--version/-v` flag to read can print older versions of the secret. Default
+version (-1) is the latest secret.
 
 ### AWS Region
 
-Chamber uses [AWS SDK for Go](https://github.com/aws/aws-sdk-go). To use a region other than what is specified in `$HOME/.aws/config`, set the environment variable "AWS_REGION".
+Chamber uses [AWS SDK for Go](https://github.com/aws/aws-sdk-go). To use a
+region other than what is specified in `$HOME/.aws/config`, set the environment
+variable "AWS_REGION".
 
 ```bash
 $ AWS_REGION=us-west-2 chamber list service
@@ -99,8 +130,12 @@ apikey      3                        07-10 09:30:41    daniel-fuentes
 other       1                        07-10 09:30:35    daniel-fuentes
 ```
 
-Chamber does not currently read the value of "AWS_DEFAULT_REGION". See [https://github.com/aws/aws-sdk-go#configuring-aws-region](https://github.com/aws/aws-sdk-go#configuring-aws-region) for more details.
+Chamber does not currently read the value of "AWS_DEFAULT_REGION". See
+[https://github.com/aws/aws-sdk-go#configuring-aws-region](https://github.com/aws/aws-sdk-go#configuring-aws-region)
+for more details.
 
 ## Releasing
 
-To cut a new release, just push a tag named `v<semver>` where `<semver>` is a valid semver version.  This tag will be used by Circle to automatically publish a github release.
+To cut a new release, just push a tag named `v<semver>` where `<semver>` is a
+valid semver version.  This tag will be used by Circle to automatically publish
+a github release.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -51,7 +51,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	env := environ(os.Environ())
-	secretStore := store.NewSSMStore()
+	secretStore := store.NewSSMStore(numRetries)
 	for _, service := range args {
 		if err := validateService(service); err != nil {
 			return errors.Wrap(err, "Failed to validate service")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -63,6 +63,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 		for _, secret := range secrets {
 			envVarKey := strings.ToUpper(key(secret.Meta.Key))
+			envVarKey = strings.Replace(envVarKey, ".", "_", -1)
 			envVarKey = strings.Replace(envVarKey, "-", "_", -1)
 
 			if env.IsSet(envVarKey) {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -54,12 +54,12 @@ func execRun(cmd *cobra.Command, args []string) error {
 	secretStore := store.NewSSMStore()
 	for _, service := range args {
 		if err := validateService(service); err != nil {
-			return err
+			return errors.Wrap(err, "Failed to validate service")
 		}
 
 		secrets, err := secretStore.List(strings.ToLower(service), true)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failed to list store contents")
 		}
 		for _, secret := range secrets {
 			envVarKey := strings.ToUpper(key(secret.Meta.Key))
@@ -92,7 +92,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	var waitStatus syscall.WaitStatus
 	if err := ecmd.Run(); err != nil {
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failed to run command")
 		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -31,12 +32,12 @@ func history(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	secretStore := store.NewSSMStore()
@@ -47,7 +48,7 @@ func history(cmd *cobra.Command, args []string) error {
 
 	events, err := secretStore.History(secretId)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to get history")
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -40,7 +40,7 @@ func history(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore()
+	secretStore := store.NewSSMStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate service")
 	}
 
-	secretStore := store.NewSSMStore()
+	secretStore := store.NewSSMStore(numRetries)
 	secrets, err := secretStore.List(service, false)
 	if err != nil {
 		return errors.Wrap(err, "Failed to list store contents")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -31,13 +32,13 @@ func list(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	secretStore := store.NewSSMStore()
 	secrets, err := secretStore.List(service, false)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to list store contents")
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -47,7 +47,7 @@ func read(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to validate key")
 	}
 
-	secretStore := store.NewSSMStore()
+	secretStore := store.NewSSMStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -38,12 +39,12 @@ func read(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	secretStore := store.NewSSMStore()
@@ -54,7 +55,7 @@ func read(cmd *cobra.Command, args []string) error {
 
 	secret, err := secretStore.Read(secretId, version)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to read")
 	}
 
 	if quiet {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 // Regex's used to validate service and key names
 var (
-	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
+	validKeyFormat     = regexp.MustCompile(`^[\.A-Za-z0-9-_]+$`)
 	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 )
 
@@ -49,7 +49,7 @@ func validateService(service string) error {
 
 func validateKey(key string) error {
 	if !validKeyFormat.MatchString(key) {
-		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, and underscores are allowed for key names", key)
+		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, periods, and underscores are allowed for key names", key)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,11 +12,16 @@ import (
 var (
 	validKeyFormat     = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
 	validServiceFormat = regexp.MustCompile(`^[A-Za-z0-9-_]+$`)
+
+	numRetries int
 )
 
 const (
 	// ShortTimeFormat is a short format for printing timestamps
 	ShortTimeFormat = "01-02 15:04:05"
+
+	// DefaultNumRetries is the default for the number of retries we'll use for our SSM client
+	DefaultNumRetries = 10
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -25,6 +30,10 @@ var RootCmd = &cobra.Command{
 	Short:         "CLI for storing secrets",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+}
+
+func init() {
+	RootCmd.PersistentFlags().IntVarP(&numRetries, "retries", "r", DefaultNumRetries, "For SSM, the number of retries we'll make before giving up")
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		fmt.Fprintf(os.Stderr, "chamber error: %s\n", err)
 		switch err {
 		case ErrTooFewArguments, ErrTooManyArguments:
 			RootCmd.Usage()

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -15,7 +17,7 @@ var (
 
 // writeCmd represents the write command
 var writeCmd = &cobra.Command{
-	Use:   "write <service> <key> <value>",
+	Use:   "write <service> <key> <value|->",
 	Short: "write a secret",
 	RunE:  write,
 }
@@ -43,6 +45,14 @@ func write(cmd *cobra.Command, args []string) error {
 	}
 
 	value := args[2]
+	if value == "-" {
+		// Read value from standard input
+		v, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+		value = string(v)
+	}
 
 	secretStore := store.NewSSMStore()
 	secretId := store.SecretId{

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -54,7 +54,7 @@ func write(cmd *cobra.Command, args []string) error {
 		value = string(v)
 	}
 
-	secretStore := store.NewSSMStore()
+	secretStore := store.NewSSMStore(numRetries)
 	secretId := store.SecretId{
 		Service: service,
 		Key:     key,

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"errors"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/segmentio/chamber/store"
 	"github.com/spf13/cobra"
 )
@@ -34,12 +34,12 @@ func write(cmd *cobra.Command, args []string) error {
 
 	service := strings.ToLower(args[0])
 	if err := validateService(service); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate service")
 	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
-		return err
+		return errors.Wrap(err, "Failed to validate key")
 	}
 
 	value := args[2]

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -20,7 +20,7 @@ const (
 )
 
 // validKeyFormat is the format that is expected for key names inside parameter store
-var validKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_]+\/[A-Za-z0-9-_]+$`)
+var validKeyFormat = regexp.MustCompile(`^\/[A-Za-z0-9-_]+\/[A-Za-z0-9-_\.]+$`)
 
 // SSMStore implements the Store interface for storing secrets in SSM Parameter
 // Store

--- a/store/ssmstore.go
+++ b/store/ssmstore.go
@@ -29,7 +29,7 @@ type SSMStore struct {
 }
 
 // NewSSMStore creates a new SSMStore
-func NewSSMStore() *SSMStore {
+func NewSSMStore(numRetries int) *SSMStore {
 	region, ok := os.LookupEnv("AWS_REGION")
 	if !ok {
 		// If region is not set, attempt to determine it via ec2 metadata API
@@ -41,7 +41,7 @@ func NewSSMStore() *SSMStore {
 	ssmSession := session.Must(session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	}))
-	svc := ssm.New(ssmSession)
+	svc := ssm.New(ssmSession, &aws.Config{MaxRetries: aws.Int(numRetries)})
 	return &SSMStore{
 		svc: svc,
 	}

--- a/store/ssmstore_test.go
+++ b/store/ssmstore_test.go
@@ -144,6 +144,15 @@ func (m *mockSSMClient) DescribeParameters(i *ssm.DescribeParametersInput) (*ssm
 	}, nil
 }
 
+func (m *mockSSMClient) DescribeParametersPages(i *ssm.DescribeParametersInput, fn func(*ssm.DescribeParametersOutput, bool) bool) error {
+	o, err := m.DescribeParameters(i)
+	if err != nil {
+		return err
+	}
+	fn(o, true)
+	return nil
+}
+
 func paramNameInSlice(name *string, slice []*string) bool {
 	for _, val := range slice {
 		if *val == *name {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,160 +3,176 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "W/q89+AUzZNVNySmkHKFERn7OxY=",
+			"checksumSHA1": "BAGzIXWxLqZRXtZohIsib8o6XIw=",
+			"path": "github.com/aws/aws-sdk-go",
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"checksumSHA1": "VGCkLl9kLkVD9pLTJMyFMy3C1Lo=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "iThCyNRL/oQFD9CF2SYgBGl+aww=",
+			"checksumSHA1": "n98FANpNeRT5kf6pizdpI7nm6Sw=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "0Gfk83qXYimO87ZoK1lL9+ifWHo=",
+			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "zu5C95rmCZff6NYZb62lEaT5ibE=",
+			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "6cj/zsRmcxkE1TLS+v910GbQYg0=",
+			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "l2O7P/kvovK2zxKhuFehFNXLk+Q=",
+			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "31f7CpCeRUQrUidzHj2uNwpBfCY=",
+			"checksumSHA1": "PQSXZY7ayypkyZm4FlI3m+G+o4k=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "junFAYG8KDpoHN9J0dkQDJHG1UA=",
+			"checksumSHA1": "n/tgGgh0wICYu+VDYSqlsRy4w9s=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "5pzA5afgeU1alfACFh8z2CDUMao=",
+			"checksumSHA1": "SK5Mn4Ga9+equOQTYA1DTSb3LWY=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "SvIsunO8D9MEKbetMENA4WRnyeE=",
+			"checksumSHA1": "iywvraxbXf3A/FOzFWjKfBBEQRA=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
+			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "lZ1z4xAbT8euCzKoAsnEYic60VE=",
+			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "O1hCpo/BItZs+ADL7VXveRKn5yg=",
+			"checksumSHA1": "jCWrivRK+K+oW2ZW3sJSuBIBNjQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "395UEmdKXxyTMbFvexUzR/y1X8o=",
+			"checksumSHA1": "cAxlijULuvw8KAphHrR1+u3+AM0=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm/ssmiface",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
 		},
 		{
-			"checksumSHA1": "o8O6Fn1ThDBMRb5OKU3UBziey+A=",
+			"checksumSHA1": "MerduaV3PxtZAWvOGpgoBIglo38=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
-			"revisionTime": "2017-03-23T00:38:48Z"
+			"revision": "58370dfb7321eb567f09391c955860bad0a747da",
+			"revisionTime": "2017-09-06T17:30:17Z"
+		},
+		{
+			"path": "github.com/aws/aws-sdk-go/ssm",
+			"revision": ""
 		},
 		{
 			"checksumSHA1": "jqSVRDK7dGg6E/NikVq1Kw6gdbA=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -202,6 +202,12 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
+			"checksumSHA1": "9guv02oL7uLkwqQNjJv8AJxWXmQ=",
+			"path": "github.com/pkg/errors",
+			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",
+			"revisionTime": "2017-03-16T20:15:38Z"
+		},
+		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",


### PR DESCRIPTION
I needed to be able to support keys with dots for the spark config thingy...

Tracker story (#151220672)
https://www.pivotaltracker.com/story/show/151220672
